### PR TITLE
Fix unintended publishing and YAML parsing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test_blog

--- a/typepad_to_jekyll
+++ b/typepad_to_jekyll
@@ -67,6 +67,9 @@ while (<$input>) {
             @categories > 1 and $categories = "categories:\n";
             $categories .= join('', map { "  - $_\n" } @categories);
             my $published = ( $status eq 'Publish' ? 'true' : 'false');
+            # Double-quote the title to avoid YAML parsing errors
+            $title =~ s/\"/\\\"/g;
+            $title = '"' . $title . '"';
             my $header = 
               "---\n"
             . "layout: post\n"

--- a/typepad_to_jekyll
+++ b/typepad_to_jekyll
@@ -66,7 +66,7 @@ while (<$input>) {
             @categories > 0 and $categories = "category:\n";
             @categories > 1 and $categories = "categories:\n";
             $categories .= join('', map { "  - $_\n" } @categories);
-            my $published = ( $status eq 'Publish' ? 1 : 0);
+            my $published = ( $status eq 'Publish' ? 'true' : 'false');
             my $header = 
               "---\n"
             . "layout: post\n"


### PR DESCRIPTION
This pull request does two things:
1. uses true and false for the published value; 1 and 0 are both truthy to Jekyll
2. double-quote blog titles to avoid YAML parsing errors when you use quotes or YAML reserved characters (like colons) in titles

Thanks for the script!
